### PR TITLE
Fix preview build Convex site URL

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,5 +1,14 @@
 import type { NextConfig } from "next";
 
+// Derive NEXT_PUBLIC_CONVEX_SITE_URL from NEXT_PUBLIC_CONVEX_URL if not set.
+// The site URL is always the cloud URL with ".convex.cloud" → ".convex.site".
+if (!process.env.NEXT_PUBLIC_CONVEX_SITE_URL && process.env.NEXT_PUBLIC_CONVEX_URL) {
+  process.env.NEXT_PUBLIC_CONVEX_SITE_URL = process.env.NEXT_PUBLIC_CONVEX_URL.replace(
+    ".convex.cloud",
+    ".convex.site"
+  );
+}
+
 const nextConfig: NextConfig = {};
 
 export default nextConfig;

--- a/apps/web/vercel-build.sh
+++ b/apps/web/vercel-build.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-set -euo pipefail
-
-cd ../../packages/backend
-
-npx convex deploy \
-  --cmd "export CONVEX_BUILD_URL=\"\\${NEXT_PUBLIC_CONVEX_URL:-\\$CONVEX_URL}\"; if [ -z \"\\$CONVEX_BUILD_URL\" ]; then echo 'Missing Convex URL in --cmd env' >&2; exit 1; fi; export NEXT_PUBLIC_CONVEX_URL=\"\\$CONVEX_BUILD_URL\"; export NEXT_PUBLIC_CONVEX_SITE_URL=$(printf %s \"\\$CONVEX_BUILD_URL\" | sed 's/\\.convex\\.cloud/.convex.site/'); cd ../../apps/web && npx next build" \
-  --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "buildCommand": "bash vercel-build.sh",
+  "buildCommand": "cd ../../packages/backend && npx convex deploy --cmd 'cd ../../apps/web && npx next build' --cmd-url-env-var-name NEXT_PUBLIC_CONVEX_URL",
   "installCommand": "pnpm install",
   "framework": "nextjs"
 }


### PR DESCRIPTION
## Summary
- set NEXT_PUBLIC_CONVEX_SITE_URL during Convex preview build command
- keep Convex preview deploy flow intact

## Testing
- not run (deploy-only change)
