### PR TITLE
Fix mobile homepage buttons and redirect logged-in users to dashboard

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,11 +1,40 @@
 import Link from "next/link";
+import { redirect } from "next/navigation";
 
-import { getServerAuth } from "@/lib/server-auth";
+import { getServerAuth, fetchAuthQuery } from "@/lib/server-auth";
+import { dateOnlyToUtcMs } from "@/lib/date-only";
+import { api } from "@repo/backend";
 
 export const dynamic = "force-dynamic";
 
 export default async function Home() {
   const { userId } = await getServerAuth();
+
+  // Redirect logged-in users to their active challenge dashboard
+  if (userId) {
+    let redirectTo = "/challenges";
+
+    try {
+      const challenges = await fetchAuthQuery<
+        Array<{ id: string; startDate: string; endDate: string }>
+      >(api.queries.challenges.listForUser, { userId, limit: 20 });
+
+      const now = Date.now();
+      const active = challenges?.find((c) => {
+        const start = dateOnlyToUtcMs(c.startDate);
+        const end = dateOnlyToUtcMs(c.endDate);
+        return now >= start && now <= end;
+      });
+
+      if (active) {
+        redirectTo = `/challenges/${active.id}/dashboard`;
+      }
+    } catch {
+      // If query fails, fall through to /challenges
+    }
+
+    redirect(redirectTo);
+  }
 
   return (
     <main className="min-h-screen bg-black text-white">
@@ -16,11 +45,11 @@ export default async function Home() {
           <div className="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-black via-black/60 to-transparent" />
         </div>
 
-        <header className="z-10 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-zinc-500">
+        <header className="relative z-10 flex items-center justify-between text-xs uppercase tracking-[0.4em] text-zinc-500">
           <span>March 2026 Edition</span>
         </header>
 
-        <div className="z-10 mt-auto flex flex-col gap-12 pb-24 pt-16 sm:pt-24">
+        <div className="relative z-10 mt-auto flex flex-col gap-12 pb-24 pt-16 sm:pt-24">
           <div className="space-y-6">
             <p className="text-sm uppercase tracking-[0.6em] text-zinc-400">Disrupt your routine</p>
             <h1 className="font-black uppercase leading-[0.85]">
@@ -39,33 +68,22 @@ export default async function Home() {
           </div>
 
           <div className="flex flex-wrap gap-4">
-            {userId ? (
-              <Link
-                href="/challenges"
-                className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white px-10 py-4 text-base font-semibold uppercase tracking-[0.2em] text-black transition hover:border-white hover:bg-black hover:text-white"
-              >
-                Enter Challenges
-              </Link>
-            ) : (
-              <>
-                <Link
-                  href="/sign-up"
-                  className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white px-10 py-4 text-base font-semibold uppercase tracking-[0.2em] text-black transition hover:border-white hover:bg-black hover:text-white"
-                >
-                  Join The Club
-                </Link>
-                <Link
-                  href="/sign-in"
-                  className="inline-flex items-center justify-center rounded-full border border-white/30 px-10 py-4 text-base font-semibold uppercase tracking-[0.2em] text-white transition hover:border-white hover:bg-white/10"
-                >
-                  Member Login
-                </Link>
-              </>
-            )}
+            <Link
+              href="/sign-up"
+              className="inline-flex items-center justify-center rounded-full border border-white/30 bg-white px-10 py-4 text-base font-semibold uppercase tracking-[0.2em] text-black transition hover:border-white hover:bg-black hover:text-white"
+            >
+              Join The Club
+            </Link>
+            <Link
+              href="/sign-in"
+              className="inline-flex items-center justify-center rounded-full border border-white/30 px-10 py-4 text-base font-semibold uppercase tracking-[0.2em] text-white transition hover:border-white hover:bg-white/10"
+            >
+              Member Login
+            </Link>
           </div>
         </div>
 
-        <footer className="z-10 mt-auto flex flex-wrap items-center justify-between gap-4 border-t border-white/10 py-6 text-xs uppercase tracking-[0.35em] text-zinc-500">
+        <footer className="relative z-10 mt-auto flex flex-wrap items-center justify-between gap-4 border-t border-white/10 py-6 text-xs uppercase tracking-[0.35em] text-zinc-500">
           <span>Competition for a good cause</span>
           <span>24/7 · Worldwide</span>
         </footer>


### PR DESCRIPTION
## Summary
- **Fix mobile tap targets**: Added `relative` to elements with `z-10` on the homepage (header, button container, footer). Without `position: relative`, `z-index` is ignored on static elements, allowing the absolutely-positioned background overlay (with blur effects) to sit above the buttons in the stacking order — causing touch issues on mobile Safari.
- **Redirect logged-in users**: Authenticated users hitting `/` are now server-side redirected to their active challenge dashboard (`/challenges/{id}/dashboard`), or `/challenges` if no active challenge exists. Removes the "Enter Challenges" button — the landing page now only renders the unauthenticated state.

## Test plan
- [ ] On mobile (iOS Safari), verify "Join The Club" and "Member Login" buttons are tappable
- [ ] Log in, visit `/` — should redirect to active challenge dashboard
- [ ] Log in with no active challenges, visit `/` — should redirect to `/challenges`
- [ ] Log out, visit `/` — should see the landing page with sign-up/sign-in buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)