### PR TITLE
Fix activity logging scoring consistency and preserve activity type configs

### DIFF
--- a/apps/web/components/dashboard/activity-log-dialog.tsx
+++ b/apps/web/components/dashboard/activity-log-dialog.tsx
@@ -88,6 +88,11 @@ function parseNumber(value: unknown): number | null {
   return Number.isFinite(numberValue) ? numberValue : null;
 }
 
+function formatPoints(value: number): string {
+  const normalized = Math.round((value + Number.EPSILON) * 100) / 100;
+  return normalized.toString();
+}
+
 interface MediaPreview {
   file: File;
   url: string;
@@ -677,12 +682,12 @@ export function ActivityLogDialog({ challengeId, challengeStartDate, trigger }: 
               {successState.activityName}
             </p>
             <p className="mt-1 text-2xl font-bold text-green-500">
-              +{successState.pointsEarned.toFixed(0)} pts
+              +{formatPoints(successState.pointsEarned)} pts
             </p>
             {successState.triggeredBonuses.length > 0 && (
               <div className="mt-3 space-y-1">
                 <p className="text-xs text-muted-foreground">
-                  {successState.basePoints.toFixed(0)} base + {successState.bonusPoints.toFixed(0)} bonus
+                  {formatPoints(successState.basePoints)} base + {formatPoints(successState.bonusPoints)} bonus
                 </p>
                 {successState.triggeredBonuses.map((bonus, i) => (
                   <Badge key={i} variant="secondary" className="bg-amber-500/10 text-amber-500">


### PR DESCRIPTION
## Summary
- fix shared scoring metric resolution so unit-based scores work across ingestion paths (e.g. `miles` vs `distance_miles`)
- stop admin activity type edits from overwriting `scoringConfig` with `{ basePoints }`
- preserve scoring config shape and update the correct points field (`pointsPerUnit`, `fixedPoints`/`points`, or `basePoints` fallback)
- show exact logged points in the activity success confirmation instead of integer rounding

## Validation
- precommit ran successfully (`turbo lint typecheck --affected`)
- `pnpm -F web typecheck`
- `cd packages/backend && npx tsc --noEmit`

## Notes
- Task files were intentionally excluded from this PR.
- Production data was corrected separately for February Warmup 2026 `Outdoor Run` scoring config.
