### PR TITLE
Fix mobile performance: defer auth into Suspense boundaries

### DIFF
--- a/apps/web/app/challenges/page.tsx
+++ b/apps/web/app/challenges/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import { redirect } from "next/navigation";
 import { ChallengesGrid } from "@/components/challenges/challenges-grid";
 import { getCurrentUser } from "@/lib/auth";
@@ -6,7 +7,41 @@ import { api } from "@repo/backend";
 
 export const dynamic = "force-dynamic";
 
-export default async function ChallengesPage() {
+function ChallengesSkeleton() {
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+      {[1, 2, 3, 4].map((i) => (
+        <div key={i} className="h-64 animate-pulse rounded-xl bg-zinc-900/50" />
+      ))}
+    </div>
+  );
+}
+
+export default function ChallengesPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground page-with-header">
+      <div className="container mx-auto px-6 py-12">
+        <div className="mb-12">
+          <h1 className="text-5xl font-black uppercase tracking-tight mb-4">
+            <span className="block">Active</span>
+            <span className="block bg-gradient-to-r from-foreground via-foreground/80 to-foreground/60 bg-clip-text text-transparent">
+              Challenges
+            </span>
+          </h1>
+          <p className="text-xl text-muted-foreground max-w-2xl">
+            Choose your challenge, compete with the community, and push your limits.
+          </p>
+        </div>
+
+        <Suspense fallback={<ChallengesSkeleton />}>
+          <ChallengesContent />
+        </Suspense>
+      </div>
+    </main>
+  );
+}
+
+async function ChallengesContent() {
   const user = await getCurrentUser();
 
   if (!user) {
@@ -27,23 +62,5 @@ export default async function ChallengesPage() {
     `[perf] challenges listPublic: ${Math.round(performance.now() - challengesStart)}ms`,
   );
 
-  return (
-    <main className="min-h-screen bg-background text-foreground page-with-header">
-      <div className="container mx-auto px-6 py-12">
-        <div className="mb-12">
-          <h1 className="text-5xl font-black uppercase tracking-tight mb-4">
-            <span className="block">Active</span>
-            <span className="block bg-gradient-to-r from-foreground via-foreground/80 to-foreground/60 bg-clip-text text-transparent">
-              Challenges
-            </span>
-          </h1>
-          <p className="text-xl text-muted-foreground max-w-2xl">
-            Choose your challenge, compete with the community, and push your limits.
-          </p>
-        </div>
-
-        <ChallengesGrid challenges={challenges} />
-      </div>
-    </main>
-  );
+  return <ChallengesGrid challenges={challenges} />;
 }

--- a/apps/web/components/layout/header-content.tsx
+++ b/apps/web/components/layout/header-content.tsx
@@ -1,0 +1,33 @@
+import { preloadAuthQuery } from "@/lib/server-auth";
+import { api } from "@repo/backend";
+import { ConditionalHeader } from "./conditional-header";
+
+/**
+ * Async server component that fetches auth data inside Suspense.
+ * This allows the root layout shell to stream immediately while
+ * the auth query resolves in parallel.
+ */
+export async function HeaderContent() {
+  const preloadedUser = await preloadAuthQuery(api.queries.users.current);
+  return <ConditionalHeader preloadedUser={preloadedUser} />;
+}
+
+/**
+ * Skeleton shown while HeaderContent is suspended.
+ * Matches the header dimensions to prevent layout shift.
+ */
+export function HeaderSkeleton() {
+  return (
+    <header className="fixed top-0 left-0 right-0 z-50 border-b border-zinc-800 bg-black/95 backdrop-blur supports-[backdrop-filter]:bg-black/60">
+      <div className="container flex h-16 items-center justify-between px-6">
+        <div className="flex items-center space-x-3">
+          <div className="h-6 w-6 rounded-full bg-gradient-to-r from-indigo-500 to-fuchsia-500" />
+          <span className="font-black text-xl uppercase tracking-wide text-white">March Fitness</span>
+        </div>
+        <div className="flex items-center space-x-3">
+          <div className="h-8 w-20 animate-pulse rounded-md bg-zinc-800" />
+        </div>
+      </div>
+    </header>
+  );
+}


### PR DESCRIPTION
## Problem
Mobile FCP was severely impacted because the root layout awaited `preloadAuthQuery` before streaming any HTML. On slow mobile connections, this meant a blank screen for seconds while the full auth → data waterfall completed.

Ref: [Convex Discord discussion](https://discord.com/channels/1019350475847499849/1280662505420623993/1470873355207835861) — auth-bound content must be wrapped in Suspense to allow streaming.

## Changes
- **`layout.tsx`**: Only await `getToken()` (fast cookie read). Defer `preloadAuthQuery` into `HeaderContent` inside `<Suspense>`.
- **`header-content.tsx`** (new): Async server component + `HeaderSkeleton` fallback.
- **`challenges/page.tsx`**: Static heading renders instantly. Auth + data fetch moved into `ChallengesContent` inside `<Suspense>` with card skeletons.
- **`dashboard/page.tsx`**: Same pattern — `DashboardContent` inside `<Suspense>` with feed skeletons.

## Result
The shell (nav bar, headings, skeleton placeholders) streams to the browser immediately. Auth and data queries resolve in parallel on the server and swap in when ready. Mobile users see content structure instantly instead of a blank screen.

## Pattern Used
Component / Content / Skeleton / Client split:
1. **Component** (sync server) — renders Suspense + fallback
2. **Content** (async server) — does the await, passes data down
3. **Skeleton** — loading fallback
4. **Client** — `usePreloadedQuery` for reactivity