### PR TITLE
Fix mobile auth reliability

### DIFF
--- a/apps/web/lib/auth.ts
+++ b/apps/web/lib/auth.ts
@@ -28,8 +28,8 @@ export const getCurrentUser = cache(async function getCurrentUser(): Promise<Doc
         {},
       );
     }
-  } catch {
-    // Auth query/mutation failed - user will remain null
+  } catch (error) {
+    console.error("[auth] getCurrentUser failed:", error);
   }
 
   return user;

--- a/apps/web/lib/better-auth/client.ts
+++ b/apps/web/lib/better-auth/client.ts
@@ -24,4 +24,10 @@ export const betterAuthClient = createAuthClient({
     credentials: "include",
   },
   plugins: [convexClient()],
+  sessionOptions: {
+    // Disable automatic refetch on tab focus — on mobile, switching apps or
+    // pulling down the notification shade triggers visibilitychange, causing
+    // unnecessary /get-session round-trips that temporarily clear auth state.
+    refetchOnWindowFocus: false,
+  },
 });

--- a/apps/web/lib/server-auth.ts
+++ b/apps/web/lib/server-auth.ts
@@ -108,8 +108,8 @@ export async function getServerAuth(): Promise<ServerAuthResult> {
         },
       };
     }
-  } catch {
-    // Query/mutation failed, fall through to unauthenticated response.
+  } catch (error) {
+    console.error("[server-auth] getServerAuth failed:", error);
   }
 
   return {

--- a/packages/backend/auth.ts
+++ b/packages/backend/auth.ts
@@ -39,6 +39,12 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
     emailAndPassword: {
       enabled: true,
     },
+    session: {
+      cookieCache: {
+        enabled: true,
+        maxAge: 5 * 60, // 5 minutes — avoids DB lookup on every /get-session
+      },
+    },
     socialProviders: {
       google: {
         clientId: process.env.GOOGLE_CLIENT_ID!,

--- a/packages/backend/http.ts
+++ b/packages/backend/http.ts
@@ -35,6 +35,10 @@ authComponent.registerRoutes(http, createAuth, {
       "http://localhost:3000",
       "http://localhost:3001",
       process.env.SITE_URL || "",
+      // Also allow www variant (matches trustedOrigins in auth.ts)
+      ...(process.env.SITE_URL
+        ? [process.env.SITE_URL.replace("://", "://www.")]
+        : []),
     ].filter(Boolean),
   },
 });


### PR DESCRIPTION
## Summary
- **Disable `refetchOnWindowFocus`** in Better Auth client — on mobile, switching apps or pulling down the notification shade triggers `visibilitychange`, causing `/get-session` round-trips that temporarily clear auth state and flicker data
- **Enable server-side session `cookieCache`** (5 min TTL) — avoids a DB lookup on every `/get-session` call, speeding up auth bootstrap on slow mobile connections
- **Add `www` variant to CORS `allowedOrigins`** in `http.ts` — was already present in `trustedOrigins` in `auth.ts` but missing from the HTTP router CORS config, causing silent CORS failures for `www.` visitors
- **Add error logging to silent `catch` blocks** — `getCurrentUser()` and `getServerAuth()` were swallowing auth errors with empty catches, making mobile failures invisible in production logs

## Test plan
- [ ] Verify auth works on mobile Safari (sign in, navigate between pages, switch away from app and return)
- [ ] Check that session persists across tab focus changes without flickering
- [ ] Verify Google OAuth flow still works on mobile
- [ ] Check Vercel logs for any `[auth]` or `[server-auth]` error messages that were previously hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)