### PR TITLE
Improve mf CLI error messages, show API keys, fix resend

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -42,6 +42,7 @@
 | 2026-02-14 | self | Tried `bun link --global` for `mf` and it failed in this environment due global Bun metadata state | Prefer repo wrapper + symlink installer script for reliable `mf` invocation without pnpm |
 | 2026-02-14 | self | Ran parallel verification commands that both mutated the same config file, creating a race and misleading results | Only parallelize independent commands; run config mutation checks sequentially |
 | 2026-02-14 | self | Implemented MCP first as `/api/[transport]` + `withMcpAuth`; valid-token requests returned non-Response at runtime in this Next 16 setup | Prefer explicit `/api/mcp` route with direct Bearer auth wrapper and request-scoped token context for reliability |
+| 2026-02-14 | self | Reused a temp config directory during profile verification and got misleading active-profile state | Use a clean temp directory (`rm -rf ...`) for deterministic config-profile tests |
 ## User Preferences
 - Always commit `.claude/napkin.md` with related task commits.
 - Avoid module-scope `new ConvexHttpClient(process.env.NEXT_PUBLIC_CONVEX_URL!)` in route handlers; lazy-init inside request handlers with env guards to prevent build-time crashes.

--- a/apps/web/components/api-key-section.tsx
+++ b/apps/web/components/api-key-section.tsx
@@ -136,15 +136,15 @@ export function ApiKeySection() {
               <p className="text-xs font-medium uppercase text-muted-foreground">
                 Active keys
               </p>
-              {keys.map((key: { id: string; name: string; keyPrefix: string; lastUsedAt?: number; createdAt: number }) => (
+              {keys.map((key: { id: string; name: string; keyPrefix: string; rawKey?: string | null; lastUsedAt?: number; createdAt: number }) => (
                 <div
                   key={key.id}
                   className="flex items-center justify-between rounded-lg border bg-muted/30 p-3"
                 >
-                  <div className="space-y-0.5">
+                  <div className="space-y-0.5 min-w-0 flex-1">
                     <p className="text-sm font-medium">{key.name}</p>
-                    <p className="text-xs text-muted-foreground font-mono">
-                      {key.keyPrefix}...
+                    <p className="text-xs text-muted-foreground font-mono break-all">
+                      {key.rawKey ?? `${key.keyPrefix}...`}
                     </p>
                     <p className="text-xs text-muted-foreground">
                       Created{" "}
@@ -223,8 +223,18 @@ export function ApiKeySection() {
             </Button>
           )}
 
-          {/* Documentation link */}
-          <div className="pt-2 border-t">
+          {/* MCP + Documentation links */}
+          <div className="pt-2 border-t space-y-3">
+            <div className="space-y-1.5">
+              <p className="text-xs font-medium uppercase text-muted-foreground">
+                Use with Claude Code
+              </p>
+              <div className="rounded-lg border bg-muted/30 p-3">
+                <code className="text-xs font-mono break-all select-all">
+                  claude mcp add march-fit https://www.march.fit/api/mcp -t streamable-http -h &quot;Authorization: Bearer {keys?.[0]?.rawKey ?? keys?.[0]?.keyPrefix ?? "YOUR_API_KEY"}&quot;
+                </code>
+              </div>
+            </div>
             <a
               href="https://github.com/prazgaitis/march-fit#api"
               target="_blank"

--- a/packages/backend/_generated/api.d.ts
+++ b/packages/backend/_generated/api.d.ts
@@ -215,7 +215,7 @@ export declare const components: {
           headers?: Array<{ name: string; value: string }>;
           replyTo?: Array<string>;
           subject: string;
-          to: string;
+          to: Array<string> | string;
         },
         string
       >;
@@ -224,9 +224,15 @@ export declare const components: {
         "internal",
         { emailId: string },
         {
+          bcc?: Array<string>;
+          bounced?: boolean;
+          cc?: Array<string>;
+          clicked?: boolean;
           complained: boolean;
           createdAt: number;
+          deliveryDelayed?: boolean;
           errorMessage?: string;
+          failed?: boolean;
           finalizedAt: number;
           from: string;
           headers?: Array<{ name: string; value: string }>;
@@ -244,9 +250,13 @@ export declare const components: {
             | "delivery_delayed"
             | "bounced"
             | "failed";
-          subject: string;
+          subject?: string;
+          template?: {
+            id: string;
+            variables?: Record<string, string | number>;
+          };
           text?: string;
-          to: string;
+          to: Array<string>;
         } | null
       >;
       getStatus: FunctionReference<
@@ -254,8 +264,12 @@ export declare const components: {
         "internal",
         { emailId: string },
         {
+          bounced: boolean;
+          clicked: boolean;
           complained: boolean;
+          deliveryDelayed: boolean;
           errorMessage: string | null;
+          failed: boolean;
           opened: boolean;
           status:
             | "waiting"
@@ -278,6 +292,8 @@ export declare const components: {
         "mutation",
         "internal",
         {
+          bcc?: Array<string>;
+          cc?: Array<string>;
           from: string;
           headers?: Array<{ name: string; value: string }>;
           html?: string;
@@ -289,9 +305,13 @@ export declare const components: {
             testMode: boolean;
           };
           replyTo?: Array<string>;
-          subject: string;
+          subject?: string;
+          template?: {
+            id: string;
+            variables?: Record<string, string | number>;
+          };
           text?: string;
-          to: string;
+          to: Array<string>;
         },
         string
       >;

--- a/packages/backend/mutations/apiKeys.ts
+++ b/packages/backend/mutations/apiKeys.ts
@@ -33,6 +33,7 @@ export const createKey = mutation({
       userId: user._id,
       keyHash,
       keyPrefix,
+      rawKey,
       name: args.name,
       createdAt: Date.now(),
     });

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@convex-dev/better-auth": "^0.10.6",
     "@convex-dev/migrations": "^0.3.1",
-    "@convex-dev/resend": "^0.2.0",
+    "@convex-dev/resend": "^0.2.3",
     "convex": "^1.28.0",
     "stripe": "^20.0.0"
   },

--- a/packages/backend/queries/apiKeys.ts
+++ b/packages/backend/queries/apiKeys.ts
@@ -24,6 +24,7 @@ export const listKeys = query({
         id: k._id,
         name: k.name,
         keyPrefix: k.keyPrefix,
+        rawKey: k.rawKey ?? null,
         lastUsedAt: k.lastUsedAt,
         createdAt: k.createdAt,
       }))

--- a/packages/backend/schema.ts
+++ b/packages/backend/schema.ts
@@ -447,6 +447,7 @@ export default defineSchema({
     userId: v.id("users"),
     keyHash: v.string(), // SHA-256 hash of the raw API key
     keyPrefix: v.string(), // First 8 chars for display (e.g., "mf_a1b2c3d4...")
+    rawKey: v.optional(v.string()), // Full key for display in UI
     name: v.string(), // User-assigned label (e.g., "CLI", "MCP Server")
     lastUsedAt: v.optional(v.number()),
     revokedAt: v.optional(v.number()),

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,8 +25,10 @@ Without installing to PATH, use:
 ## Commands
 
 ```bash
-mf config show
-mf config set --base-url <url> --challenge <challengeId> --api-key <key>
+mf --config local config show
+mf --config local config set --base-url <url> --challenge <challengeId> --api-key <key>
+mf config profiles
+mf config use <name>
 mf config clear-challenge
 mf config clear-api-key
 
@@ -40,9 +42,10 @@ mf leaderboard [--api-key <key>] [--challenge <challengeId>]
 ## Config
 
 Config is stored at:
-- macOS/Linux: `~/.config/mf/config.json`
-- Windows: `%APPDATA%/mf/config.json`
+- macOS/Linux: `~/.config/mf/configs/<name>.json`
+- Windows: `%APPDATA%/mf/configs/<name>.json`
 - If set, `XDG_CONFIG_HOME` is used.
+- Active profile name is stored at `~/.config/mf/active-config`.
 - Local Convex Docker default API base URL: `http://127.0.0.1:3211/api/v1`
 
 Config shape:
@@ -57,9 +60,36 @@ Config shape:
 
 `--challenge` always overrides `challengeId` from config.
 
+## Profiles (local/prod switching)
+
+Examples:
+
+```bash
+# Configure local profile
+mf --config local config set --base-url http://127.0.0.1:3211 --api-key mf_local_key
+
+# Configure prod profile
+mf --config prod config set --base-url https://www.march.fit --api-key mf_prod_key
+
+# Set default active profile
+mf config use prod
+
+# One-off override for a single command
+mf --config local me
+```
+
+## Verbose Mode
+
+Use `--verbose` (or `-v`) to print resolved environment/request context
+(profile, base URL source, API key source, challenge source) before results:
+
+```bash
+mf --config local --verbose me
+```
+
 ## API Key
 
 Resolution order:
 1. `--api-key <key>`
 2. `MF_API_KEY`
-3. `config.apiKey` from `mf config set --api-key <key>`
+3. `config.apiKey` from active/specified config profile

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -266,8 +266,8 @@ importers:
         specifier: ^0.3.1
         version: 0.3.1(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))
       '@convex-dev/resend':
-        specifier: ^0.2.0
-        version: 0.2.0(convex-helpers@0.1.106(@standard-schema/spec@1.1.0)(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(hono@4.11.9)(react@19.2.4)(typescript@5.9.2)(zod@4.2.1))(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(react@19.2.4)
+        specifier: ^0.2.3
+        version: 0.2.3(convex-helpers@0.1.106(@standard-schema/spec@1.1.0)(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(hono@4.11.9)(react@19.2.4)(typescript@5.9.2)(zod@4.2.1))(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(react@19.2.4)
       convex:
         specifier: ^1.28.0
         version: 1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
@@ -488,11 +488,11 @@ packages:
       react:
         optional: true
 
-  '@convex-dev/resend@0.2.0':
-    resolution: {integrity: sha512-HTGN42ZNPhwkhy7B1mqfwURj2IUMWLdhfIZKa8JyQIA4zmsQM6muT2F99NFEi9Zu+xYR4GVXm1oErqv/NlHE2A==}
+  '@convex-dev/resend@0.2.3':
+    resolution: {integrity: sha512-eH7xmj49u0nZVvHyztxg3BLrBq2hJAVxJDBdmFFK07zgUCblGq+Pp6k7X+YtmBHcj8Eie4J0kUFeElu8L4KtBg==}
     peerDependencies:
       convex: ^1.24.8
-      convex-helpers: ^0.1.99
+      convex-helpers: ^0.1.106
 
   '@convex-dev/workpool@0.3.0':
     resolution: {integrity: sha512-nY8Ub0pmfuxZ2rcnNwVeESYPyJqLU4h+afodEdg8Ifnr+vcFUuee/p69vMFmeqC2y4yo9IDPHrdiVZVyjbBE7A==}
@@ -5900,6 +5900,9 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
+  postal-mime@2.7.3:
+    resolution: {integrity: sha512-MjhXadAJaWgYzevi46+3kLak8y6gbg0ku14O1gO/LNOuay8dO+1PtcSGvAdgDR0DoIsSaiIA8y/Ddw6MnrO0Tw==}
+
   postcss-selector-parser@6.0.10:
     resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
     engines: {node: '>=4'}
@@ -6207,6 +6210,15 @@ packages:
   requires-port@1.0.0:
     resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
+  resend@6.9.2:
+    resolution: {integrity: sha512-uIM6CQ08tS+hTCRuKBFbOBvHIGaEhqZe8s4FOgqsVXSbQLAhmNWpmUhG3UAtRnmcwTWFUqnHa/+Vux8YGPyDBA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@react-email/render': '*'
+    peerDependenciesMeta:
+      '@react-email/render':
+        optional: true
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -6455,6 +6467,9 @@ packages:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -6608,6 +6623,9 @@ packages:
 
   svix@1.75.0:
     resolution: {integrity: sha512-3GLI1DN4Pfd8Ze+7yxoV3Ocp8hW07/WRDsoIBdjDvR916Fx3gRHaYSoa0WWRdKSqJNj+OTCeDSSv47mSp9ibqw==}
+
+  svix@1.84.1:
+    resolution: {integrity: sha512-K8DPPSZaW/XqXiz1kEyzSHYgmGLnhB43nQCMeKjWGCUpLIpAMMM8kx3rVVOSm6Bo6EHyK1RQLPT4R06skM/MlQ==}
 
   swap-case@1.1.2:
     resolution: {integrity: sha512-BAmWG6/bx8syfc6qXPprof3Mn5vQgf5dwdUNJhsNqU9WdPt5P+ES/wQ5bxfijy8zwZgZZHslC3iAsxsuQMCzJQ==}
@@ -7475,7 +7493,7 @@ snapshots:
       '@better-auth/utils': 0.3.0
       '@better-fetch/fetch': 1.1.21
       '@standard-schema/spec': 1.1.0
-      better-call: 1.1.5(zod@4.1.5)
+      better-call: 1.1.5(zod@4.2.1)
       jose: 6.1.3
       kysely: 0.28.9
       nanostores: 1.1.0
@@ -7620,15 +7638,17 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
 
-  '@convex-dev/resend@0.2.0(convex-helpers@0.1.106(@standard-schema/spec@1.1.0)(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(hono@4.11.9)(react@19.2.4)(typescript@5.9.2)(zod@4.2.1))(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(react@19.2.4)':
+  '@convex-dev/resend@0.2.3(convex-helpers@0.1.106(@standard-schema/spec@1.1.0)(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(hono@4.11.9)(react@19.2.4)(typescript@5.9.2)(zod@4.2.1))(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(react@19.2.4)':
     dependencies:
       '@convex-dev/rate-limiter': 0.3.0(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(react@19.2.4)
       '@convex-dev/workpool': 0.3.0(convex-helpers@0.1.106(@standard-schema/spec@1.1.0)(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(hono@4.11.9)(react@19.2.4)(typescript@5.9.2)(zod@4.2.1))(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))
       convex: 1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)
       convex-helpers: 0.1.106(@standard-schema/spec@1.1.0)(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(hono@4.11.9)(react@19.2.4)(typescript@5.9.2)(zod@4.2.1)
       remeda: 2.32.0
+      resend: 6.9.2
       svix: 1.75.0
     transitivePeerDependencies:
+      - '@react-email/render'
       - react
 
   '@convex-dev/workpool@0.3.0(convex-helpers@0.1.106(@standard-schema/spec@1.1.0)(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))(hono@4.11.9)(react@19.2.4)(typescript@5.9.2)(zod@4.2.1))(convex@1.28.0(@clerk/clerk-react@5.45.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4))':
@@ -13374,6 +13394,8 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
+  postal-mime@2.7.3: {}
+
   postcss-selector-parser@6.0.10:
     dependencies:
       cssesc: 3.0.0
@@ -13782,6 +13804,11 @@ snapshots:
 
   requires-port@1.0.0: {}
 
+  resend@6.9.2:
+    dependencies:
+      postal-mime: 2.7.3
+      svix: 1.84.1
+
   resolve-from@4.0.0: {}
 
   resolve-pkg-maps@1.0.0: {}
@@ -14110,6 +14137,11 @@ snapshots:
     dependencies:
       type-fest: 0.7.1
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@3.9.0: {}
@@ -14306,6 +14338,11 @@ snapshots:
       es6-promise: 4.2.8
       fast-sha256: 1.3.0
       url-parse: 1.5.10
+      uuid: 10.0.0
+
+  svix@1.84.1:
+    dependencies:
+      standardwebhooks: 1.0.0
       uuid: 10.0.0
 
   swap-case@1.1.2:


### PR DESCRIPTION
## Summary
- **CLI error messages**: Show actionable errors with the URL that failed and hints (e.g. "check your base URL", "check your API key") instead of generic "Request failed with 404"
- **Show full API keys**: Store raw API key in DB so it can be displayed in the profile UI and pre-filled into the `claude mcp add` command
- **MCP command in UI**: API key section now shows a ready-to-copy `claude mcp add march-fit ...` command with the user's actual key
- **Fix `@convex-dev/resend` build error**: Updated from 0.2.0 to 0.2.3 to fix esbuild exports resolution

## Test plan
- [ ] Create a new API key and verify the full key is shown in the list
- [ ] Verify the MCP command in the API key section uses the real key
- [ ] Run `mf me` with an invalid base URL and verify the error message includes the URL
- [ ] Run `mf me` with an invalid API key and verify the hint mentions `mf config show`
- [ ] Verify `pnpm dev` starts without the resend esbuild error

🤖 Generated with [Claude Code](https://claude.com/claude-code)