### PR TITLE
feat: add participant role management to API, CLI, and MCP

### DIFF
--- a/apps/web/app/api/mcp/route.ts
+++ b/apps/web/app/api/mcp/route.ts
@@ -249,6 +249,29 @@ const mcpHandler = createMcpHandler(
     // ─── Admin Tools (require challenge admin role) ─────────────────────
 
     server.registerTool(
+      "update_participant_role",
+      {
+        title: "Update Participant Role",
+        description:
+          "Set a participant's role in a challenge (member or admin). Requires challenge admin role.",
+        inputSchema: {
+          challengeId: z.string().min(1),
+          userId: z.string().min(1),
+          role: z.enum(["member", "admin"]),
+        },
+      },
+      async ({ challengeId, userId, role }) => {
+        const token = requireApiToken();
+        const data = await apiRequest(
+          token,
+          `/challenges/${challengeId}/participants/${userId}`,
+          { method: "PATCH", body: { role } }
+        );
+        return asTextResult(data);
+      }
+    );
+
+    server.registerTool(
       "update_challenge",
       {
         title: "Update Challenge",


### PR DESCRIPTION
Adds ability for challenge admins to change participant roles (member ↔ admin) via:
- HTTP API: PATCH /api/v1/challenges/:id/participants/:userId
- MCP tool: update_participant_role
- CLI: mf participants set-role / mf participants list

Requires challenge admin, challenge creator, or global admin role.