### PR TITLE
Fix: properly handle ConvexError in activity feed flag dialog

### DIFF
--- a/apps/web/components/dashboard/activity-feed.tsx
+++ b/apps/web/components/dashboard/activity-feed.tsx
@@ -16,6 +16,7 @@ import {
 import { useMutation, usePaginatedQuery } from 'convex/react';
 import { api } from '@repo/backend';
 import type { Id } from '@repo/backend/_generated/dataModel';
+import { ConvexError } from 'convex/values';
 
 import dynamic from 'next/dynamic';
 import { RichTextViewer } from '@/components/editor/rich-text-viewer';
@@ -435,6 +436,7 @@ function ActivityCard({
       setFlagReason('');
     } catch (err) {
       setFlagError(
+        err instanceof ConvexError ? (err.data as string) :
         err instanceof Error ? err.message : 'Failed to report activity'
       );
     } finally {


### PR DESCRIPTION
Fixes #34

The activity feed flag error handler only checked `err instanceof Error`, causing `ConvexError` messages to display as unhelpful generic errors.

Adds `ConvexError` import and check before the `Error` check, matching the existing pattern in `activity-detail-content.tsx`.