### PR TITLE
Fix scoped admin access across admin pages and flagged activity actions

### DIFF
--- a/.claude/napkin.md
+++ b/.claude/napkin.md
@@ -64,3 +64,7 @@
 - Root layout auth preloads can execute during static prerender (`/_not-found`); guard token preload and fail open when auth env vars are absent at build time.
 - Vercel can ignore root `vercel.json` when project Root Directory is `apps/web`; keep an `apps/web/vercel.json` with the Convex deploy build command to avoid accidental `pnpm build` fallback.
 - For CLI work in this repo, prefer Bun runtime (`bun ...`) when feasible.
+| 2026-02-17 | self | Ran `ls` before reading napkin at session start | Always read `.claude/napkin.md` as the first command in every session |
+| 2026-02-17 | self | Ran `sed` on bracketed Next route paths without quoting, causing zsh `no matches found` | Always single-quote paths containing `[id]` before `sed`/`cat`/`rg` |
+| 2026-02-17 | self | Queried prod with `queries/users:getByEmailPublic` and failed because deployed function name was `queries/users:getByEmail` | When checking prod Convex, list available functions from error output and call the deployed name instead of assuming local function names |
+| 2026-02-17 | self | Missed a closing quote in a `sed` command for a bracketed path and got `unmatched '` | Double-check shell quoting when commands include `[id]` paths before execution |

--- a/apps/web/app/challenges/[id]/admin/activity-types/page.tsx
+++ b/apps/web/app/challenges/[id]/admin/activity-types/page.tsx
@@ -2,7 +2,6 @@ import { getConvexClient } from "@/lib/convex-server";
 import { api } from "@repo/backend";
 import type { Id } from "@repo/backend/_generated/dataModel";
 
-import { requireAuth } from "@/lib/auth";
 import { getChallengeOrThrow } from "@/lib/challenge-helpers";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AdminActivityTypesTable } from "@/components/admin/admin-activity-types-table";
@@ -15,11 +14,14 @@ export default async function ActivityTypesAdminPage({
   params,
 }: ActivityTypesAdminPageProps) {
   const convex = getConvexClient();
-  const user = await requireAuth();
   const { id } = await params;
   const challenge = await getChallengeOrThrow(id);
 
-  if (challenge.creatorId !== user._id && user.role !== "admin") {
+  const adminStatus = await convex.query(api.queries.participations.isUserChallengeAdmin, {
+    challengeId: challenge.id as Id<"challenges">,
+  });
+
+  if (!adminStatus.isAdmin) {
     return null;
   }
 

--- a/apps/web/app/challenges/[id]/admin/flagged-activities/page.tsx
+++ b/apps/web/app/challenges/[id]/admin/flagged-activities/page.tsx
@@ -4,7 +4,6 @@ import { getConvexClient } from "@/lib/convex-server";
 import { api } from "@repo/backend";
 import type { Id } from "@repo/backend/_generated/dataModel";
 
-import { requireAuth } from "@/lib/auth";
 import { getChallengeOrThrow } from "@/lib/challenge-helpers";
 import { flaggedActivitiesQuerySchema } from "@/lib/validations";
 import { Badge } from "@/components/ui/badge";
@@ -39,12 +38,15 @@ export default async function FlaggedActivitiesPage({
   searchParams,
 }: FlaggedActivitiesPageProps) {
   const convex = getConvexClient();
-  const user = await requireAuth();
   const { id } = await params;
   const searchParamsResolved = await searchParams;
   const challenge = await getChallengeOrThrow(id);
 
-  if (challenge.creatorId !== user._id && user.role !== "admin") {
+  const adminStatus = await convex.query(api.queries.participations.isUserChallengeAdmin, {
+    challengeId: challenge.id as Id<"challenges">,
+  });
+
+  if (!adminStatus.isAdmin) {
     return null;
   }
 

--- a/apps/web/app/challenges/[id]/admin/integrations/page.tsx
+++ b/apps/web/app/challenges/[id]/admin/integrations/page.tsx
@@ -2,7 +2,6 @@ import { getConvexClient } from "@/lib/convex-server";
 import { api } from "@repo/backend";
 import type { Id } from "@repo/backend/_generated/dataModel";
 
-import { requireAuth } from "@/lib/auth";
 import { getChallengeOrThrow } from "@/lib/challenge-helpers";
 import { IntegrationsTabs } from "./integrations-tabs";
 
@@ -14,11 +13,14 @@ export default async function IntegrationsAdminPage({
   params,
 }: IntegrationsAdminPageProps) {
   const convex = getConvexClient();
-  const user = await requireAuth();
   const { id } = await params;
   const challenge = await getChallengeOrThrow(id);
 
-  if (challenge.creatorId !== user._id && user.role !== "admin") {
+  const adminStatus = await convex.query(api.queries.participations.isUserChallengeAdmin, {
+    challengeId: challenge.id as Id<"challenges">,
+  });
+
+  if (!adminStatus.isAdmin) {
     return null;
   }
 

--- a/tasks/2026-02-17-admin-scope-prod-verification.md
+++ b/tasks/2026-02-17-admin-scope-prod-verification.md
@@ -1,0 +1,8 @@
+# 2026-02-17 Admin Scope Prod Verification
+
+- [x] Identify where admin access is scoped in code (backend + web checks)
+- [x] Verify production data for `prazgaitis@gmail.com` (user + admin role bindings)
+- [x] Confirm prod environment configuration used by admin checks
+- [x] Pinpoint mismatch between code and data causing missing admin access
+- [x] Implement/fix code if needed and validate
+- [x] Summarize findings and exact remediation steps


### PR DESCRIPTION
## Summary
- align challenge admin authorization checks across admin pages with `isUserChallengeAdmin`
- fix flagged activity admin mutations to authorize challenge admins (not only global admins)
- add investigation task log for production validation

## What was wrong
A prior PR updated admin layout gating, but several nested admin pages and backend flagged-activity mutations still used global-admin/creator checks. That left scoped challenge admins blocked in parts of the admin flow.

## Changed files
- `apps/web/app/challenges/[id]/admin/activity-types/page.tsx`
- `apps/web/app/challenges/[id]/admin/integrations/page.tsx`
- `apps/web/app/challenges/[id]/admin/flagged-activities/page.tsx`
- `apps/web/app/challenges/[id]/admin/flagged-activities/[activityId]/page.tsx`
- `packages/backend/mutations/admin.ts`
- `tasks/2026-02-17-admin-scope-prod-verification.md`
- `.claude/napkin.md`

## Verification
- `pnpm -F web typecheck`
- `pnpm -F backend exec tsc --noEmit`
- precommit checks passed on commit (`turbo lint typecheck --affected`)

## Prod data validation done during investigation
- confirmed `users` record for `prazgaitis@gmail.com` exists with role `admin`
- confirmed participation rows checked in prod include challenge admin role where expected
