### PR TITLE
Fix: Hide payment column in admin participants when payment not required

### DIFF
--- a/apps/web/app/challenges/[id]/admin/participants/page.tsx
+++ b/apps/web/app/challenges/[id]/admin/participants/page.tsx
@@ -181,7 +181,7 @@ export default function AdminParticipantsPage() {
               #
             </span>
           </div>
-          <div className="col-span-3">
+          <div className={requiresPayment ? "col-span-3" : "col-span-4"}>
             <SortHeader field="name">Participant</SortHeader>
           </div>
           <div className="col-span-1">
@@ -189,11 +189,13 @@ export default function AdminParticipantsPage() {
               Role
             </span>
           </div>
-          <div className="col-span-2">
-            <span className="text-[10px] font-medium uppercase tracking-wider text-zinc-500">
-              Payment
-            </span>
-          </div>
+          {requiresPayment && (
+            <div className="col-span-2">
+              <span className="text-[10px] font-medium uppercase tracking-wider text-zinc-500">
+                Payment
+              </span>
+            </div>
+          )}
           <div className="col-span-2 text-right">
             <SortHeader field="points" className="justify-end">
               Points
@@ -224,7 +226,7 @@ export default function AdminParticipantsPage() {
                     {index + 1}
                   </span>
                 </div>
-                <div className="col-span-3 flex items-center gap-2">
+                <div className={cn("flex items-center gap-2", requiresPayment ? "col-span-3" : "col-span-4")}>
                   <div className="flex h-6 w-6 items-center justify-center rounded-full bg-zinc-800">
                     {participant.user.avatarUrl ? (
                       <img
@@ -258,8 +260,8 @@ export default function AdminParticipantsPage() {
                     {participant.role}
                   </span>
                 </div>
-                <div className="col-span-2">
-                  {requiresPayment ? (
+                {requiresPayment && (
+                  <div className="col-span-2">
                     <span
                       className={cn(
                         "inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide",
@@ -269,10 +271,8 @@ export default function AdminParticipantsPage() {
                     >
                       {participant.paymentStatus}
                     </span>
-                  ) : (
-                    <span className="text-xs text-zinc-500">N/A</span>
-                  )}
-                </div>
+                  </div>
+                )}
                 <div className="col-span-2 text-right">
                   <div className="flex items-center justify-end gap-1">
                     <Trophy className="h-3 w-3 text-amber-400" />


### PR DESCRIPTION
## Problem
The admin participants page always shows a "Payment" column with payment status (paid/unpaid/pending/failed), even for challenges that don't require payment. This is confusing and makes it seem like all challenges require payment.

## Solution
- Query `getPublicPaymentInfo` to check if the challenge actually requires payment
- Conditionally show/hide the Payment column based on `requiresPayment` flag
- Adjust grid layout to use the freed-up space when payment column is hidden
- Participant name column expands from col-span-3 to col-span-4 when no payment

## Impact
- Cleaner admin UI for free challenges
- No more misleading "PAID" status for challenges that don't require payment
- Better use of screen space