### PR TITLE
Fix admin payments config sync with server state

### DIFF
--- a/apps/web/app/challenges/[id]/admin/payments/page.tsx
+++ b/apps/web/app/challenges/[id]/admin/payments/page.tsx
@@ -79,12 +79,16 @@ export default function PaymentsAdminPage() {
   const toggleTestMode = useMutation(api.mutations.paymentConfig.toggleTestMode);
   const testConnection = useAction(api.actions.payments.testStripeConnection);
 
-  // Sync allowCustomAmount from paymentConfig when it loads
+  // Sync form state from server when paymentConfig loads
   useEffect(() => {
-    if (paymentConfig !== undefined) {
+    if (paymentConfig != null) {
       setFormData((prev) => ({
         ...prev,
-        allowCustomAmount: paymentConfig?.allowCustomAmount ?? false,
+        testMode: paymentConfig.testMode,
+        priceInDollars: (paymentConfig.priceInCents / 100).toString(),
+        allowCustomAmount: paymentConfig.allowCustomAmount ?? false,
+        stripePublishableKey: paymentConfig.stripePublishableKey ?? "",
+        stripeTestPublishableKey: paymentConfig.stripeTestPublishableKey ?? "",
       }));
     }
   }, [paymentConfig]);
@@ -103,7 +107,7 @@ export default function PaymentsAdminPage() {
         stripeTestPublishableKey: formData.stripeTestPublishableKey || undefined,
         stripeWebhookSecret: formData.stripeWebhookSecret || undefined,
         stripeTestWebhookSecret: formData.stripeTestWebhookSecret || undefined,
-        testMode: formData.testMode,
+        testMode: paymentConfig?.testMode ?? formData.testMode,
         priceInCents,
         allowCustomAmount: formData.allowCustomAmount,
       });

--- a/packages/backend/queries/paymentConfig.ts
+++ b/packages/backend/queries/paymentConfig.ts
@@ -37,6 +37,7 @@ export const getPaymentConfig = query({
       testMode: config.testMode,
       priceInCents: config.priceInCents,
       currency: config.currency,
+      allowCustomAmount: config.allowCustomAmount ?? false,
       createdAt: config.createdAt,
       updatedAt: config.updatedAt,
     };

--- a/tasks/fix-admin-payments-sync.md
+++ b/tasks/fix-admin-payments-sync.md
@@ -1,0 +1,19 @@
+# Fix Admin Payments Config Sync
+
+**Date:** 2026-02-20
+**Description:** Admin panel payments section was not correctly syncing form state with the challengePaymentConfig table, causing saved values to be overwritten with defaults.
+
+## Bugs Found
+
+- [x] `getPaymentConfig` query did not return `allowCustomAmount` field — donation mode toggle always reset to off on page load
+- [x] `useEffect` only synced `allowCustomAmount` from server, not `priceInDollars`, `testMode`, or publishable keys — saving would reset price to $0
+- [x] `handleSave` sent `formData.testMode` (stale default of `true`) instead of the server's `paymentConfig.testMode` — could flip test mode on every save
+
+## Changes
+
+### `packages/backend/queries/paymentConfig.ts`
+- Added `allowCustomAmount` to the `getPaymentConfig` query return object
+
+### `apps/web/app/challenges/[id]/admin/payments/page.tsx`
+- Expanded `useEffect` to sync `testMode`, `priceInDollars`, `allowCustomAmount`, `stripePublishableKey`, and `stripeTestPublishableKey` from server state when `paymentConfig` loads
+- Changed `handleSave` to use `paymentConfig?.testMode` (authoritative server state) instead of `formData.testMode` (stale local state)


### PR DESCRIPTION
## Summary

Fixes a critical bug where the admin panel payments section was not correctly syncing form state with the server's `challengePaymentConfig` table. This caused saved configuration values to be overwritten with defaults on page load or save.

### Root Causes
1. `getPaymentConfig` query was missing the `allowCustomAmount` field, causing the donation mode toggle to always reset to off
2. `useEffect` only synced `allowCustomAmount` from the server, leaving `priceInDollars`, `testMode`, and Stripe keys out of sync
3. `handleSave` was sending `formData.testMode` (stale local state) instead of `paymentConfig.testMode` (authoritative server state), potentially flipping test mode on every save

### Changes
- **`packages/backend/queries/paymentConfig.ts`**: Added `allowCustomAmount` to the query return object
- **`apps/web/app/challenges/[id]/admin/payments/page.tsx`**: 
  - Expanded `useEffect` to sync all payment config fields (`testMode`, `priceInDollars`, `allowCustomAmount`, `stripePublishableKey`, `stripeTestPublishableKey`) from server state
  - Updated `handleSave` to use `paymentConfig?.testMode` instead of `formData.testMode` to preserve server state

## Testing
- [x] pnpm lint
- [x] pnpm typecheck

## Notes
This fix ensures that the admin payments form always reflects the authoritative server state and prevents accidental overwrites of configuration values during save operations.

https://claude.ai/code/session_01T9zPKkNT2UdtSKQov5CSt6