### PR TITLE
Fix payment step and add resetPaymentStatus

### DIFF
--- a/apps/web/components/dashboard/onboarding-card.tsx
+++ b/apps/web/components/dashboard/onboarding-card.tsx
@@ -216,7 +216,7 @@ export function OnboardingCard({ challengeId, userId, challengeStartDate }: Onbo
                   />
                 )}
                 {step.key === "payment" && (
-                  <PaymentStep challengeId={challengeId} />
+                  <PaymentStep challengeId={challengeId} complete={paymentComplete} />
                 )}
                 {step.key === "strava" && (
                   <StravaStep
@@ -422,12 +422,21 @@ function BioForm({
 }
 
 // --- Payment Step ---
-function PaymentStep({ challengeId }: { challengeId: string }) {
+function PaymentStep({ challengeId, complete }: { challengeId: string; complete: boolean }) {
   const [isRedirecting, setIsRedirecting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const createCheckoutSession = useAction(
     api.actions.payments.createCheckoutSession
   );
+
+  if (complete) {
+    return (
+      <div className="text-sm text-green-400 flex items-center gap-2">
+        <Check className="h-4 w-4" />
+        Paid
+      </div>
+    );
+  }
 
   const handlePay = async () => {
     setErrorMessage(null);

--- a/packages/backend/mutations/payments.ts
+++ b/packages/backend/mutations/payments.ts
@@ -151,6 +151,38 @@ export const clearTestPayment = mutation({
 });
 
 /**
+ * Internal mutation: reset a user's payment status to "unpaid".
+ * Used for admin testing of the payment flow.
+ */
+export const resetPaymentStatus = internalMutation({
+  args: {
+    userId: v.id("users"),
+    challengeId: v.id("challenges"),
+  },
+  handler: async (ctx, args) => {
+    const participation = await ctx.db
+      .query("userChallenges")
+      .withIndex("userChallengeUnique", (q) =>
+        q.eq("userId", args.userId).eq("challengeId", args.challengeId)
+      )
+      .first();
+
+    if (!participation) {
+      throw new Error("Participation not found");
+    }
+
+    await ctx.db.patch(participation._id, {
+      paymentStatus: "unpaid",
+      paymentReceivedAt: undefined,
+      paymentReference: undefined,
+      updatedAt: Date.now(),
+    });
+
+    return { success: true };
+  },
+});
+
+/**
  * Internal mutation: prepare a checkout by validating state and creating DB records.
  * Called by the createCheckoutSession action after it creates the Stripe session.
  */


### PR DESCRIPTION
## Summary
- **PaymentStep shows "Paid" when already paid** — previously always showed "Pay now" button, causing a server error when clicked by users already marked as paid
- **Add `resetPaymentStatus` internal mutation** — allows resetting a user's payment status to "unpaid" via CLI for admin testing of the payment flow

## Test plan
- [ ] Join a challenge with payment configured while already marked as paid — should show green "Paid" instead of "Pay now"
- [ ] Join a challenge with payment required while unpaid — should show "Pay now" button that redirects to Stripe
- [ ] Run `npx convex run mutations/payments:resetPaymentStatus '{"userId": "...", "challengeId": "..."}' --prod` to reset payment status

🤖 Generated with [Claude Code](https://claude.com/claude-code)